### PR TITLE
BXC-4742 TIFs failing to generate JP2s

### DIFF
--- a/src/main/java/JP2ImageConverter/services/ColorFieldsService.java
+++ b/src/main/java/JP2ImageConverter/services/ColorFieldsService.java
@@ -41,6 +41,7 @@ public class ColorFieldsService {
     public static final String DATE_TIME_DIGITIZED = "DateTimeDigitized";
     public static final String ICC_PROFILE_NAME = "ICCProfileName";
     public static final String COLOR_SPACE = "ColorSpace";
+    public static final String A_TO_B0 = "AToB0";
     public static final String INTEROP_INDEX = "InteropIndex";
     public static final String PHOTOMETRIC_INTERPRETATION = "PhotometricInterpretation";
     public static final String MAGICK_IDENTIFY = "MagickIdentify";
@@ -59,6 +60,7 @@ public class ColorFieldsService {
         String dateTimeDigitized = null;
         String iccProfileName = null;
         String colorSpace = null;
+        String aToB0 = null;
         String interopIndex = null;
         String photometricInterpretation = null;
         String orientation = null;
@@ -67,7 +69,7 @@ public class ColorFieldsService {
         try {
             Metadata metadata = ImageMetadataReader.readMetadata(imageFile);
 
-            // ICC Profile Tag(s): ICCProfileName, ColorSpace
+            // ICC Profile Tag(s): ICCProfileName, ColorSpace, AToB0
             if (metadata.containsDirectoryOfType(IccDirectory.class)) {
                 IccDirectory iccDirectory = metadata.getFirstDirectoryOfType(IccDirectory.class);
                 if (iccDirectory.containsTag(IccDirectory.TAG_TAG_desc)) {
@@ -75,6 +77,9 @@ public class ColorFieldsService {
                 }
                 if (iccDirectory.containsTag(IccDirectory.TAG_COLOR_SPACE)) {
                     colorSpace = iccDirectory.getDescription(IccDirectory.TAG_COLOR_SPACE).trim();
+                }
+                if (iccDirectory.containsTag(IccDirectory.TAG_TAG_A2B0)) {
+                    aToB0 = iccDirectory.getDescription(IccDirectory.TAG_TAG_A2B0).trim();
                 }
             }
 
@@ -125,7 +130,7 @@ public class ColorFieldsService {
         }
 
         // image metadata: ImageFileName, FileSize, FileModifiedDate, DateTimeOriginal, DateTimeDigitized,
-        // ICCProfileName, ColorSpace, InteropIndex, PhotometricInterpretation, Orientation
+        // ICCProfileName, ColorSpace, AToB0, InteropIndex, PhotometricInterpretation, Orientation
         Map<String, String> imageMetadata = new LinkedHashMap<>();
         imageMetadata.put(IMAGE_FILE_NAME, fileName);
         imageMetadata.put(FILE_SIZE, fileSize);
@@ -134,6 +139,7 @@ public class ColorFieldsService {
         imageMetadata.put(DATE_TIME_DIGITIZED, dateTimeDigitized);
         imageMetadata.put(ICC_PROFILE_NAME, iccProfileName);
         imageMetadata.put(COLOR_SPACE, colorSpace);
+        imageMetadata.put(A_TO_B0, aToB0);
         imageMetadata.put(INTEROP_INDEX, interopIndex);
         imageMetadata.put(PHOTOMETRIC_INTERPRETATION, photometricInterpretation);
         imageMetadata.put(ORIENTATION, orientation);

--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -35,14 +35,14 @@ public class ImagePreproccessingService {
     }
 
     /**
-     * For images with CMYK color space
+     * For images with unusual colorspaces and unsupported ICC Profiles
      * Run GraphicsMagick convert and convert TIFF to temporary TIFF
      * @param fileName an image file
      * @return temporaryFile a temporary TIFF file
      */
     //It seems like only using color space creates a more color accurate temporary image.
     //Using color space and ICC Profile or just the ICC Profile create a temporary image with slightly different colors.
-    public String convertCmykAndYcbcrColorSpace(String fileName) throws Exception {
+    public String convertUnusualColorSpace(String fileName) throws Exception {
         String gm = "gm";
         String convert = "convert";
         String colorSpace = "-colorspace";
@@ -220,7 +220,7 @@ public class ImagePreproccessingService {
     /**
      * Determine image color space and preprocess if needed
      * for unusual color spaces: convert to temporary TIFF and set color space to RGB before kdu_compress
-     * currently supported color spaces: RGB, sRGB, RGB Palette, Gray, CMYK
+     * currently supported color spaces: RGB, sRGB, RGB Palette, Gray, CMYK, AToB0 (technically an ICC Profile)
      * @param colorSpace an image color space
      * @param fileName an image file
      * @return inputFile a path to a TIFF image file
@@ -229,8 +229,9 @@ public class ImagePreproccessingService {
         String inputFile;
         Set<String> colorSpaces = new HashSet<>(Arrays.asList("rgb", "srgb", "rgb palette", "gray"));
 
-        if (colorSpace.toLowerCase().matches("cmyk") || colorSpace.toLowerCase().matches("ycbcr")) {
-            inputFile = convertCmykAndYcbcrColorSpace(fileName);
+        if (colorSpace.toLowerCase().matches("cmyk") || colorSpace.toLowerCase().matches("ycbcr")
+            || colorSpace.toLowerCase().matches("atob0")) {
+            inputFile = convertUnusualColorSpace(fileName);
         } else if (colorSpaces.contains(colorSpace.toLowerCase())) {
             inputFile = fileName;
         } else {

--- a/src/main/java/JP2ImageConverter/services/KakaduService.java
+++ b/src/main/java/JP2ImageConverter/services/KakaduService.java
@@ -104,6 +104,11 @@ public class KakaduService {
             colorSpace = "Gray";
         }
 
+        // If the original image has the ICCProfile AToB0, set the color space to aToB0
+        if (originalImageMetadata.get(ColorFieldsService.A_TO_B0) != null) {
+            colorSpace = "aToB0";
+        }
+
         return colorSpace;
     }
 

--- a/src/test/java/JP2ImageConverter/services/ColorFieldsServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ColorFieldsServiceTest.java
@@ -34,6 +34,7 @@ public class ColorFieldsServiceTest {
         testFields.put(ColorFieldsService.DATE_TIME_DIGITIZED, "2021:08:30 19:56:48");
         testFields.put(ColorFieldsService.ICC_PROFILE_NAME, "Adobe RGB (1998)");
         testFields.put(ColorFieldsService.COLOR_SPACE, "RGB");
+        testFields.put(ColorFieldsService.A_TO_B0, null);
         testFields.put(ColorFieldsService.INTEROP_INDEX, "Unknown (R03)");
         testFields.put(ColorFieldsService.PHOTOMETRIC_INTERPRETATION, "RGB");
 
@@ -60,6 +61,7 @@ public class ColorFieldsServiceTest {
         testFields.put(ColorFieldsService.DATE_TIME_DIGITIZED, "2013:06:25 14:51:58");
         testFields.put(ColorFieldsService.ICC_PROFILE_NAME, null);
         testFields.put(ColorFieldsService.COLOR_SPACE, null);
+        testFields.put(ColorFieldsService.A_TO_B0, null);
         testFields.put(ColorFieldsService.INTEROP_INDEX, null);
         testFields.put(ColorFieldsService.PHOTOMETRIC_INTERPRETATION, "BlackIsZero");
 

--- a/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
@@ -36,7 +36,7 @@ public class ImagePreprocessingServiceTest {
     @Test
     public void testConvertCmykImageWithIccProfile() throws Exception {
         String testFile = "src/test/resources/OP20459_1_TremorsKelleyandtheCowboys.tif";
-        var tempTif = service.convertCmykAndYcbcrColorSpace(testFile);
+        var tempTif = service.convertUnusualColorSpace(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -48,7 +48,7 @@ public class ImagePreprocessingServiceTest {
     @Test
     public void testConvertCmykImageWithoutIccProfile() throws Exception {
         String testFile = "src/test/resources/Surgery.tif";
-        var tempTif = service.convertCmykAndYcbcrColorSpace(testFile);
+        var tempTif = service.convertUnusualColorSpace(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4742](https://unclibrary.atlassian.net/browse/BXC-4742)

The failing TIFs contain the ICC Profile AtoB0, which is not allowed in JP2. To fix this, we can preprocess images with AtoB0 metadata and remove the ICC Profiles.

- `ColorFieldsService`: add `AtoB0` to the list of extracted metadata fields
- `ImagePreprocessingService`: renamed `convertCmykAndYcbcrColorSpace` to `convertUnusualColorSpace`, add `AtoB0` to `convertColorSpaces` method
- `KakaduService`:  add `aToB0` to `getColorSpace`