### PR TITLE
BXC-4789 CIELab color space not supported

### DIFF
--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -275,7 +275,8 @@ public class ImagePreproccessingService {
     public String convertColorSpaces(String colorSpace, String fileName) throws Exception {
         String inputFile;
         Set<String> colorSpaces = new HashSet<>(Arrays.asList("rgb", "srgb", "rgb palette", "gray"));
-        Set<String> unusualColorSpaces = new HashSet<>(Arrays.asList("cmyk", "ycbcr", "atob0", "color filter array"));
+        Set<String> unusualColorSpaces = new HashSet<>(Arrays.asList("cmyk", "ycbcr", "atob0", "color filter array",
+                "cielab"));
 
         if (unusualColorSpaces.contains(colorSpace.toLowerCase())) {
             inputFile = convertUnusualColorSpace(fileName);

--- a/src/main/java/JP2ImageConverter/services/KakaduService.java
+++ b/src/main/java/JP2ImageConverter/services/KakaduService.java
@@ -284,7 +284,8 @@ public class KakaduService {
                                      Map<String, String> metadata, List<String> intermediateFiles) throws Exception {
         var fileBeforeColorConversion = inputFile;
         var orientation = metadata.get(ColorFieldsService.ORIENTATION);
-        // for unusual color spaces (CMYK, YcbCr, AtoB0, Color Filter Array): convert to temporary TIFF before kduCompress
+        // convert unusual color spaces to temporary TIFF before kduCompress
+        // unusual color spaces: CMYK, YcbCr, AtoB0, Color Filter Array, CIELab
         inputFile = imagePreproccessingService.convertColorSpaces(colorInfo.get(COLOR_SPACE), inputFile);
         if (!fileBeforeColorConversion.equals(inputFile)) {
             intermediateFiles.add(inputFile);

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -94,15 +94,6 @@ public class KakaduServiceTest {
     }
 
     @Test
-    public void testKduCompressCieLabJpeg() throws Exception {
-        String testFile = "src/test/resources/DSC_2990.TIF";
-        service.kduCompress(testFile, Paths.get(tmpFolder + "/DSC_2990.TIF"), "");
-
-        assertTrue(Files.exists(tmpFolder.resolve("DSC_2990.TIF.jp2")));
-        assertEquals(1, Files.list(tmpFolder).count());
-    }
-
-    @Test
     public void testKduCompressPng() throws Exception {
         String testFile = "src/test/resources/schoolphotos1.png";
         service.kduCompress(testFile, Paths.get(tmpFolder + "/schoolphotos1"), "");

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -94,6 +94,15 @@ public class KakaduServiceTest {
     }
 
     @Test
+    public void testKduCompressCieLabJpeg() throws Exception {
+        String testFile = "src/test/resources/DSC_2990.TIF";
+        service.kduCompress(testFile, Paths.get(tmpFolder + "/DSC_2990.TIF"), "");
+
+        assertTrue(Files.exists(tmpFolder.resolve("DSC_2990.TIF.jp2")));
+        assertEquals(1, Files.list(tmpFolder).count());
+    }
+
+    @Test
     public void testKduCompressPng() throws Exception {
         String testFile = "src/test/resources/schoolphotos1.png";
         service.kduCompress(testFile, Paths.get(tmpFolder + "/schoolphotos1"), "");


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4789](https://unclibrary.atlassian.net/browse/BXC-4789)

- add `CIELab` to list of unusual colorspaces in `convertColorSpaces`
- add test and test resource
