### PR TITLE
BXC-4790 image/x-nikon-nrw not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It can also retrieve image metadata using EXIF fields and the ImageMagick identi
 ## Image Conversion
 ### Image Formats
 The JP2ImageConverter supports the following image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, JP2, 
-NEF, CRW, CR2, DNG, RAF.
+NEF, NRW, CRW, CR2, DNG, RAF, RW2.
 
 Kakadu kduCompress struggles to convert non-TIFF images. To work around this, we preprocess images in other formats.
 This involves converting non-TIFF images to temporary TIFF files. 

--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -168,11 +168,11 @@ public class ImagePreproccessingService {
     }
 
     /**
-     * Run Exiftool to convert NEF images to JPEG
-     * @param fileName an image file
+     * Run Exiftool to convert NEF and NRW images to JPEG
+     * @param fileName an NEF or NRW image file
      * @return temporaryFile a temporary JPEG file
      */
-    public String convertNef(String fileName) throws Exception {
+    public String convertNefAndNrw(String fileName) throws Exception {
         String b = "-b";
         String jpgFromRaw = "-JpgFromRaw";
         String inputFile = fileName;
@@ -181,7 +181,7 @@ public class ImagePreproccessingService {
         List<String> command = Arrays.asList(EXIFTOOL, b, jpgFromRaw, inputFile);
         CommandUtility.executeCommandWriteToFile(command, temporaryFile);
 
-        // Next, copy over orientation info from the original NEF to the new JPEG
+        // Next, copy over orientation info from the original NEF/NRW to the new JPEG
         List<String> command2 = Arrays.asList(EXIFTOOL, "-overwrite_original", "-tagsfromfile", inputFile, "-orientation", temporaryFile);
         CommandUtility.executeCommand(command2);
 
@@ -237,7 +237,7 @@ public class ImagePreproccessingService {
     /**
      * Determine image format and preprocess if needed
      * for non-TIFF image formats: convert to temporary TIFF/PPM before kdu_compress
-     * currently supported image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, NEF, CRW, CR2, DNG, RAF, PCD, RW2
+     * currently supported image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, NEF, NRW, CRW, CR2, DNG, RAF, PCD, RW2
      * @param fileName an image file
      * @param sourceFormat file extension/mimetype override
      * @return inputFile a path to a TIFF/PPM image file
@@ -264,9 +264,9 @@ public class ImagePreproccessingService {
             inputFile = convertPcd(fileName);
         } else if (fileNameExtension.matches("rw2")) {
             inputFile = convertRw2(fileName);
-        } else if (fileNameExtension.matches("nef")) {
-            // convert NEF to JPEG, then convert JPEG to PPM
-            String tempJpeg = convertNef(fileName);
+        } else if (fileNameExtension.matches("nef") || fileNameExtension.matches("nrw")) {
+            // convert NEF/NRW to JPEG, then convert JPEG to PPM
+            String tempJpeg = convertNefAndNrw(fileName);
             inputFile = convertJpeg(tempJpeg);
             // delete temp JPEG after temp PPM is created
             Files.deleteIfExists(Path.of(tempJpeg));

--- a/src/main/java/JP2ImageConverter/services/KakaduService.java
+++ b/src/main/java/JP2ImageConverter/services/KakaduService.java
@@ -24,7 +24,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Service for Kakadu kduCompress
- * Supported image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, JP2, NEF, CRW, CR2, DNG, RAF, PCD
+ * Supported image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, JP2, NEF, NRW, CRW, CR2, DNG, RAF, PCD
  * @author krwong
  */
 public class KakaduService {
@@ -58,6 +58,8 @@ public class KakaduService {
         SOURCE_FORMATS.put("image/jp2", "jp2");
         SOURCE_FORMATS.put("nef", "nef");
         SOURCE_FORMATS.put("image/x-nikon-nef", "nef");
+        SOURCE_FORMATS.put("nrw", "nrw");
+        SOURCE_FORMATS.put("image/x-nikon-nrw", "nrw");
         SOURCE_FORMATS.put("crw", "crw");
         SOURCE_FORMATS.put("image/x-canon-crw", "crw");
         SOURCE_FORMATS.put("cr2", "cr2");
@@ -274,7 +276,7 @@ public class KakaduService {
      * @param inputFile
      * @param fileName
      * @param sourceFormat
-     * @param colorSpace
+     * @param colorInfo
      * @param metadata extracted metadata from the source image
      * @param intermediateFiles
      * @return

--- a/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
@@ -200,7 +200,7 @@ public class ImagePreprocessingServiceTest {
                 "MagickIdentify:\"Dimensions: 4272x2848;Channels: srgb  3.0;Bit-depth: 8;Alpha channel: Undefined;" +
                 "Color Space: sRGB;Profiles: ;ICC Profile: ;ICM Profile: ;Type: TrueColor;\"";
 
-        var tempTif = service.convertNef(testFile);
+        var tempTif = service.convertNefAndNrw(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -208,6 +208,23 @@ public class ImagePreprocessingServiceTest {
         assertContains("MagickIdentify:", attributes);
         assertContains("Dimensions: 4272x2848;", attributes);
         assertContains("Channels: srgb", attributes);
+        assertContains("Color Space: sRGB;", attributes);
+        assertContains("Profiles: exif;", attributes);
+        assertContains("Type: TrueColor;", attributes);
+    }
+
+    @Test
+    public void testConvertNrwToJpeg() throws Exception {
+        String testFile = "src/test/resources/20170726_010.NRW";
+
+        var tempJpeg = service.convertNefAndNrw(testFile);
+        colorFieldsService.listFields(tempJpeg);
+
+        assertTrue(Files.exists(Paths.get(tempJpeg)));
+        var attributes = outputStreamCaptor.toString();
+        assertContains("MagickIdentify:", attributes);
+        assertContains("Dimensions: 4000x3000;", attributes);
+        assertContains("Channels: srgb  3.0", attributes);
         assertContains("Color Space: sRGB;", attributes);
         assertContains("Profiles: exif;", attributes);
         assertContains("Type: TrueColor;", attributes);

--- a/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
@@ -36,7 +36,7 @@ public class ImagePreprocessingServiceTest {
     @Test
     public void testConvertCmykImageWithIccProfile() throws Exception {
         String testFile = "src/test/resources/OP20459_1_TremorsKelleyandtheCowboys.tif";
-        var tempTif = service.convertUnusualColorSpace(testFile);
+        var tempTif = service.setColorSpaceRemoveProfileWithIm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -48,7 +48,7 @@ public class ImagePreprocessingServiceTest {
     @Test
     public void testConvertCmykImageWithoutIccProfile() throws Exception {
         String testFile = "src/test/resources/Surgery.tif";
-        var tempTif = service.convertUnusualColorSpace(testFile);
+        var tempTif = service.setColorSpaceRemoveProfileWithIm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -60,7 +60,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertJpegtoPpm() throws Exception {
         String testFile = "src/test/resources/IMG_2377.jpeg";
 
-        var tempPpm = service.convertJpeg(testFile);
+        var tempPpm = service.convertToPpmWithIm(testFile);
 
         assertTrue(Files.exists(Paths.get(tempPpm)));
     }
@@ -69,7 +69,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertRw2ToPpm() throws Exception {
         String testFile = "src/test/resources/test.RW2";
 
-        var tempPpm = service.convertRw2(testFile);
+        var tempPpm = service.convertToPpmWithDcraw(testFile);
 
         assertTrue(Files.exists(Paths.get(tempPpm)));
     }
@@ -78,7 +78,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertPngToTiff() throws Exception {
         String testFile = "src/test/resources/schoolphotos1.png";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -97,7 +97,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertGifToTiff() throws Exception {
         String testFile = "src/test/resources/CARTEZOO.GIF";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -118,7 +118,7 @@ public class ImagePreprocessingServiceTest {
                 "MagickIdentify:\"Dimensions: 1600x1200;Channels: srgb  3.0;Bit-depth: 8;Alpha channel: Undefined;" +
                 "Color Space: sRGB;Profiles: 8bim,icc;ICC Profile: sRGB IEC61966-2.1;ICM Profile: ;Type: TrueColor;\"";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -137,7 +137,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertBmpToTiff() throws Exception {
         String testFile = "src/test/resources/Wagoner_BW.bmp";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -157,7 +157,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertPsdToTiff() throws Exception {
         String testFile = "src/test/resources/17.psd";
 
-        var tempTif = service.convertPsd(testFile);
+        var tempTif = service.flattenSetColorspaceConvertToTifWithIm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -178,7 +178,7 @@ public class ImagePreprocessingServiceTest {
                 "MagickIdentify:\"Dimensions: 1228x1818;Channels: srgb  3.0;Bit-depth: 8;Alpha channel: Undefined;" +
                 "Color Space: sRGB;Profiles: icc;ICC Profile: sRGB IEC61966-2.1;ICM Profile: ;Type: TrueColor;\"";
 
-        var tempTif = service.convertJp2(testFile);
+        var tempTif = service.convertToTifWithIm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -200,7 +200,7 @@ public class ImagePreprocessingServiceTest {
                 "MagickIdentify:\"Dimensions: 4272x2848;Channels: srgb  3.0;Bit-depth: 8;Alpha channel: Undefined;" +
                 "Color Space: sRGB;Profiles: ;ICC Profile: ;ICM Profile: ;Type: TrueColor;\"";
 
-        var tempTif = service.convertNefAndNrw(testFile);
+        var tempTif = service.convertToJpgWithExiftool(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -217,7 +217,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertNrwToJpeg() throws Exception {
         String testFile = "src/test/resources/20170726_010.NRW";
 
-        var tempJpeg = service.convertNefAndNrw(testFile);
+        var tempJpeg = service.convertToJpgWithExiftool(testFile);
         colorFieldsService.listFields(tempJpeg);
 
         assertTrue(Files.exists(Paths.get(tempJpeg)));
@@ -234,7 +234,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertCrwToTiff() throws Exception {
         String testFile = "src/test/resources/CanonEOS10D.crw";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -252,7 +252,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertCr2ToTiff() throws Exception {
         String testFile = "src/test/resources/CanonEOS350D.CR2";
 
-        var tempPpm = service.convertCr2(testFile);
+        var tempPpm = service.convertToPpmWithGm(testFile);
 
         assertTrue(Files.exists(Paths.get(tempPpm)));
     }
@@ -261,7 +261,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertPcdToTiff() throws Exception {
         String testFile = "src/test/resources/98-337.03.PCD";
 
-        var tempTif = service.convertPcd(testFile);
+        var tempTif = service.convertToTifHighestResolutionWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -277,7 +277,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertDngToTiff() throws Exception {
         String testFile = "src/test/resources/DJIPhantom4.dng";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));
@@ -295,7 +295,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertRafToTiff() throws Exception {
         String testFile = "src/test/resources/FujiFilmFinePixS5500.raf";
 
-        var tempTif = service.convertImageFormats(testFile);
+        var tempTif = service.convertToTifWithGm(testFile);
         colorFieldsService.listFields(tempTif);
 
         assertTrue(Files.exists(Paths.get(tempTif)));

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -174,6 +174,15 @@ public class KakaduServiceTest {
     }
 
     @Test
+    public void testKduCompressNrw() throws Exception {
+        String testFile = "src/test/resources/20170726_010.NRW";
+        service.kduCompress(testFile, Paths.get(tmpFolder + "/20170726_010"), "");
+
+        assertTrue(Files.exists(tmpFolder.resolve("20170726_010.jp2")));
+        assertEquals(1, Files.list(tmpFolder).count());
+    }
+
+    @Test
     public void testKduCompressCrw() throws Exception {
         String testFile = "src/test/resources/CanonEOS10D.crw";
         service.kduCompress(testFile, Paths.get(tmpFolder + "/CanonEOS10D"), "");


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4790](https://unclibrary.atlassian.net/browse/BXC-4790)

- renamed `convertNef` to `convertNefAndNrw` and add `nrw` to javadoc/comments
- add `nrw` and `image/x-nikon-nrw` to map of accepted `source_formats`
- add tests and test resource
- update readme