### PR TITLE
BXC-4821 fix errors found while regenerating JP2s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <junit.platform.version>1.9.1</junit.platform.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.13</logback.version>
+        <mockito.version>5.11.0</mockito.version>
+        <mockito.junit.version>5.11.0</mockito.junit.version>
     </properties>
 
     <dependencies>
@@ -59,6 +61,18 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -295,6 +295,10 @@ public class ImagePreproccessingService {
 
         if (colorSpace.toLowerCase().contains("cielab")) {
             inputFile = setColorSpaceWithIm(fileName);
+        } else if (colorSpace.toLowerCase().contains("ycbcr") && FilenameUtils.isExtension(fileName, "tif")) {
+            // rarely, Kakadu can't parse a TIFF with a YCbCr photometric interpretation even after correction
+            // convert the TIFF to a PPM before JP2 generation
+            inputFile = convertToPpmWithGm(fileName);
         } else if (unusualColorSpaces.contains(colorSpace.toLowerCase())) {
             inputFile = setColorSpaceRemoveProfileWithIm(fileName);
         } else if (colorSpaces.contains(colorSpace.toLowerCase())) {

--- a/src/main/java/JP2ImageConverter/services/KakaduService.java
+++ b/src/main/java/JP2ImageConverter/services/KakaduService.java
@@ -249,6 +249,12 @@ public class KakaduService {
                     intermediateFiles.add(modifiedTmpPath);
                     performKakaduCommandWithRecovery(command, intermediateFiles, false);
                     return;
+                } else if (output.contains("no_palette") && output.contains("to avoid nasty palettization effects")) {
+                    // rarely, there is a TIFF that requires -no_palatte to generate a JP2
+                    log.warn("Optimizing palette error, retrying with -no_palette: {}", e.getMessage());
+                    command.add("-no_palette");
+                    performKakaduCommandWithRecovery(command, intermediateFiles, false);
+                    return;
                 }
             }
             throw e;


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4821](https://unclibrary.atlassian.net/browse/BXC-4821)

- for TIFFs with YCbCr color spaces, preprocess TIFFs and convert them to PPMs before kakadu JP2 generation
- if kakadu command output contains an optimizing palette error and suggests using `-no_palette`, retry the command with `-no_palette`