### PR TITLE
BXC-4829 fix image strangeness in viewer

### DIFF
--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -235,6 +235,23 @@ public class ImagePreproccessingService {
     }
 
     /**
+     * Using GraphicsMagick, set the type to TrueColor and colorspace to sRGB for the provided image
+     * For images with type "Palette" and colorspace "RGB Palette"
+     * @param fileName
+     * @return
+     * @throws Exception
+     */
+    public String setTypeAndColorspaceWithGm(String fileName) throws Exception {
+        String temporaryFile = String.valueOf(prepareTempPath(fileName, ".tif"));
+
+        List<String> command = Arrays.asList(GM, CONVERT, AUTO_ORIENT, "-type", "TrueColor",
+                "-colorspace", "sRGB", fileName,temporaryFile);
+        CommandUtility.executeCommand(command);
+
+        return temporaryFile;
+    }
+
+    /**
      * Determine image format and preprocess if needed
      * for non-TIFF image formats: convert to temporary TIFF/PPM before kdu_compress
      * currently supported image formats: TIFF, JPEG, PNG, GIF, PICT, BMP, PSD, NEF, NRW, CRW, CR2, DNG, RAF, PCD, RW2
@@ -285,15 +302,18 @@ public class ImagePreproccessingService {
      * for unusual color spaces: convert to temporary TIFF and set color space to RGB before kdu_compress
      * currently supported color spaces: RGB, sRGB, RGB Palette, Gray, CMYK, AToB0 (technically an ICC Profile)
      * @param colorSpace an image color space
+     * @param type an image type
      * @param fileName an image file
      * @return inputFile a path to a TIFF image file
      */
-    public String convertColorSpaces(String colorSpace, String fileName) throws Exception {
+    public String convertColorSpaces(String colorSpace, String type, String fileName) throws Exception {
         String inputFile;
         Set<String> colorSpaces = new HashSet<>(Arrays.asList("rgb", "srgb", "rgb palette", "gray"));
         Set<String> unusualColorSpaces = new HashSet<>(Arrays.asList("cmyk", "ycbcr", "atob0", "color filter array"));
 
-        if (colorSpace.toLowerCase().contains("cielab")) {
+        if (colorSpace.toLowerCase().contains("rgb palette") && type.toLowerCase().contains("palette")) {
+            inputFile = setTypeAndColorspaceWithGm(fileName);
+        } else if (colorSpace.toLowerCase().contains("cielab")) {
             inputFile = setColorSpaceWithIm(fileName);
         } else if (unusualColorSpaces.contains(colorSpace.toLowerCase())) {
             inputFile = setColorSpaceRemoveProfileWithIm(fileName);

--- a/src/main/java/JP2ImageConverter/services/KakaduService.java
+++ b/src/main/java/JP2ImageConverter/services/KakaduService.java
@@ -288,7 +288,8 @@ public class KakaduService {
         var orientation = metadata.get(ColorFieldsService.ORIENTATION);
         // convert unusual color spaces to temporary TIFF before kduCompress
         // unusual color spaces: CMYK, YcbCr, AtoB0, Color Filter Array, CIELab
-        inputFile = imagePreproccessingService.convertColorSpaces(colorInfo.get(COLOR_SPACE), inputFile);
+        inputFile = imagePreproccessingService.convertColorSpaces(colorInfo.get(COLOR_SPACE),
+                colorInfo.get(COLOR_TYPE), inputFile);
         if (!fileBeforeColorConversion.equals(inputFile)) {
             intermediateFiles.add(inputFile);
             return inputFile;

--- a/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
@@ -353,7 +353,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertColorspace() throws Exception {
         String testFile = "src/test/resources/IMG_3444.pct.tif";
 
-        String result = service.convertColorSpaces("rgb", testFile);
+        String result = service.convertColorSpaces("rgb", "truecolor", testFile);
 
         assertEquals(testFile, result);
     }
@@ -362,7 +362,7 @@ public class ImagePreprocessingServiceTest {
     public void testConvertUnusualColorspace() throws Exception {
         String testFile = "src/test/resources/OP20459_1_TremorsKelleyandtheCowboys.tif";
 
-        String result = service.convertColorSpaces("cmyk", testFile);
+        String result = service.convertColorSpaces("cmyk", "colorseparation", testFile);
 
         assertTrue(Files.exists(Paths.get(result)));
     }

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -424,7 +424,7 @@ public class KakaduServiceTest {
         when(colorFieldsService.identifyType(anyString())).thenReturn("TrueColor");
         ImagePreproccessingService imagePreproccessingService = mock(ImagePreproccessingService.class);
         when(imagePreproccessingService.convertToTiff(anyString(), anyString())).thenReturn(mockedTif);
-        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString())).thenReturn(mockedTif);
+        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString(), anyString())).thenReturn(mockedTif);
 
         try (MockedStatic<CommandUtility> mockedStatic = Mockito.mockStatic(CommandUtility.class)) {
             String mockedJp2 = tmpFolder.resolve("mockedImage.jp2").toString();
@@ -445,7 +445,7 @@ public class KakaduServiceTest {
             verify(imagePreproccessingService, times(1))
                     .convertToTiff(mockedTif, "tiff");
             verify(imagePreproccessingService, times(1))
-                    .convertColorSpaces("YCbCr", mockedTif);
+                    .convertColorSpaces("YCbCr", "TrueColor", mockedTif);
         }
     }
 
@@ -458,7 +458,7 @@ public class KakaduServiceTest {
         when(colorFieldsService.identifyType(anyString())).thenReturn("TrueColor");
         ImagePreproccessingService imagePreproccessingService = mock(ImagePreproccessingService.class);
         when(imagePreproccessingService.convertToTiff(anyString(), anyString())).thenReturn(mockedTif);
-        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString())).thenReturn(mockedTif);
+        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString(), anyString())).thenReturn(mockedTif);
 
         try (MockedStatic<CommandUtility> mockedStatic = Mockito.mockStatic(CommandUtility.class)) {
             String mockedJp2 = tmpFolder.resolve("mockedImage.jp2").toString();
@@ -477,9 +477,10 @@ public class KakaduServiceTest {
                             "Cprecincts={256,256},{256,256},{128,128}", "Stiles={512,512}", "Corder=RPCL",
                             "ORGgen_plt=yes", "ORGtparts=R", "Cblk={64,64}", "Cuse_sop=yes", "Cuse_eph=yes",
                             "-flush_period", "1024", "-rate", "3", "-no_weights"))));
-            verify(imagePreproccessingService, times(1)).convertToTiff(mockedTif, "tiff");
             verify(imagePreproccessingService, times(1))
-                    .convertColorSpaces("RGB", mockedTif);
+                    .convertToTiff(mockedTif, "tiff");
+            verify(imagePreproccessingService, times(1))
+                    .convertColorSpaces("RGB", "TrueColor", mockedTif);
         }
     }
 
@@ -492,7 +493,7 @@ public class KakaduServiceTest {
         when(colorFieldsService.identifyType(anyString())).thenReturn("Palette");
         ImagePreproccessingService imagePreproccessingService = mock(ImagePreproccessingService.class);
         when(imagePreproccessingService.convertToTiff(anyString(), anyString())).thenReturn(mockedTif);
-        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString())).thenReturn(mockedTif);
+        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString(), anyString())).thenReturn(mockedTif);
 
         try (MockedStatic<CommandUtility> mockedStatic = Mockito.mockStatic(CommandUtility.class)) {
             String mockedJp2 = tmpFolder.resolve("mockedImage.jp2").toString();
@@ -508,8 +509,10 @@ public class KakaduServiceTest {
                             "Clevels=6", "Clayers=6", "Cprecincts={256,256},{256,256},{128,128}", "" +
                             "Stiles={512,512}", "Corder=RPCL", "ORGgen_plt=yes", "ORGtparts=R", "Cblk={64,64}",
                             "Cuse_sop=yes", "Cuse_eph=yes", "-flush_period", "1024", "-rate", "3", "-no_weights"))));
-            verify(imagePreproccessingService, times(1)).convertToTiff(mockedTif, "tiff");
-            verify(imagePreproccessingService, times(1)).convertColorSpaces("RGB Palette", "Palette", mockedTif);
+            verify(imagePreproccessingService, times(1))
+                    .convertToTiff(mockedTif, "tiff");
+            verify(imagePreproccessingService, times(1))
+                    .convertColorSpaces("RGB Palette", "Palette", mockedTif);
         }
     }
 

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -393,7 +393,7 @@ public class KakaduServiceTest {
 
     @Test
     public void testKduCompressTiffWithPaletteTypeAndColorSpace() throws Exception {
-        String mockedTif = String.valueOf(new File( tmpFolder + "/mockedImage.tif"));
+        String mockedTif = tmpFolder.resolve("mockedImage.tif").toString();
         Map<String, String> imageMetadata = Map.of(ColorFieldsService.COLOR_SPACE, "RGB Palette");
         ColorFieldsService colorFieldsService = mock(ColorFieldsService.class);
         when(colorFieldsService.extractMetadataFields(anyString())).thenReturn(imageMetadata);
@@ -403,8 +403,8 @@ public class KakaduServiceTest {
         when(imagePreproccessingService.convertColorSpaces(anyString(), anyString())).thenReturn(mockedTif);
 
         try (MockedStatic<CommandUtility> mockedStatic = Mockito.mockStatic(CommandUtility.class)) {
-            File mockedJp2 = new File(tmpFolder + "/mockedImage.jp2");
-            mockedStatic.when(() -> CommandUtility.executeCommand(anyList())).thenReturn(String.valueOf(mockedJp2));
+            String mockedJp2 = tmpFolder.resolve("mockedImage.jp2").toString();
+            mockedStatic.when(() -> CommandUtility.executeCommand(anyList())).thenReturn(mockedJp2);
 
             KakaduService service = new KakaduService();
             service.setColorFieldsService(colorFieldsService);
@@ -412,11 +412,11 @@ public class KakaduServiceTest {
             service.kduCompress(mockedTif, tmpFolder.resolve("mockedImage"), "");
 
             mockedStatic.verify(() -> CommandUtility.executeCommand(
-                    new ArrayList<>(Arrays.asList("kdu_compress", "-i", mockedTif, "-o", mockedJp2.toString(),
+                    new ArrayList<>(Arrays.asList("kdu_compress", "-i", mockedTif, "-o", mockedJp2,
                             "Clevels=6", "Clayers=6", "Cprecincts={256,256},{256,256},{128,128}", "" +
                             "Stiles={512,512}", "Corder=RPCL", "ORGgen_plt=yes", "ORGtparts=R", "Cblk={64,64}",
                             "Cuse_sop=yes", "Cuse_eph=yes", "-flush_period", "1024", "-rate", "3", "-no_weights"))));
-            verify(imagePreproccessingService, times(1)).convertToTiff(mockedTif, "tif");
+            verify(imagePreproccessingService, times(1)).convertToTiff(mockedTif, "tiff");
             verify(imagePreproccessingService, times(1)).convertColorSpaces("RGB Palette", "Palette", mockedTif);
         }
     }

--- a/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/KakaduServiceTest.java
@@ -391,6 +391,36 @@ public class KakaduServiceTest {
         assertContains("2832x4256", output);
     }
 
+    @Test
+    public void testKduCompressTiffWithPaletteTypeAndColorSpace() throws Exception {
+        String mockedTif = String.valueOf(new File( tmpFolder + "/mockedImage.tif"));
+        Map<String, String> imageMetadata = Map.of(ColorFieldsService.COLOR_SPACE, "RGB Palette");
+        ColorFieldsService colorFieldsService = mock(ColorFieldsService.class);
+        when(colorFieldsService.extractMetadataFields(anyString())).thenReturn(imageMetadata);
+        when(colorFieldsService.identifyType(anyString())).thenReturn("Palette");
+        ImagePreproccessingService imagePreproccessingService = mock(ImagePreproccessingService.class);
+        when(imagePreproccessingService.convertToTiff(anyString(), anyString())).thenReturn(mockedTif);
+        when(imagePreproccessingService.convertColorSpaces(anyString(), anyString())).thenReturn(mockedTif);
+
+        try (MockedStatic<CommandUtility> mockedStatic = Mockito.mockStatic(CommandUtility.class)) {
+            File mockedJp2 = new File(tmpFolder + "/mockedImage.jp2");
+            mockedStatic.when(() -> CommandUtility.executeCommand(anyList())).thenReturn(String.valueOf(mockedJp2));
+
+            KakaduService service = new KakaduService();
+            service.setColorFieldsService(colorFieldsService);
+            service.setImagePreproccessingService(imagePreproccessingService);
+            service.kduCompress(mockedTif, tmpFolder.resolve("mockedImage"), "");
+
+            mockedStatic.verify(() -> CommandUtility.executeCommand(
+                    new ArrayList<>(Arrays.asList("kdu_compress", "-i", mockedTif, "-o", mockedJp2.toString(),
+                            "Clevels=6", "Clayers=6", "Cprecincts={256,256},{256,256},{128,128}", "" +
+                            "Stiles={512,512}", "Corder=RPCL", "ORGgen_plt=yes", "ORGtparts=R", "Cblk={64,64}",
+                            "Cuse_sop=yes", "Cuse_eph=yes", "-flush_period", "1024", "-rate", "3", "-no_weights"))));
+            verify(imagePreproccessingService, times(1)).convertToTiff(mockedTif, "tif");
+            verify(imagePreproccessingService, times(1)).convertColorSpaces("RGB Palette", "Palette", mockedTif);
+        }
+    }
+
     private void assertContains(String expected, String actual) {
         assertTrue(actual.contains(expected), "Expected string '" + expected + "' not found: " + actual);
     }


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4829](https://unclibrary.atlassian.net/browse/BXC-4829)

- add `setTypeAndColorspaceWithGm` method to set the type to `TrueColor` and colorspace to `sRGB` for a provided image
- add type param to `convertColorspaces` and if an image type=Palette and colorspace=RGB Palette, modify the image with `setTypeAndColorSpaceWithGm` 
- add/modify tests