### PR TITLE
BXC-5702 fix yellow access copies

### DIFF
--- a/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
+++ b/src/main/java/JP2ImageConverter/services/ImagePreproccessingService.java
@@ -127,9 +127,11 @@ public class ImagePreproccessingService {
      */
     public String convertToTifWithIm(String fileName) throws Exception {
         String importFile = fileName;
+        // remove embedded ICC Profiles, which aren't used for colorspace identifying info
+        String strip = "-strip";
         String temporaryFile = String.valueOf(prepareTempPath(fileName, ".tif"));
 
-        List<String> command = Arrays.asList(CONVERT, AUTO_ORIENT, importFile, temporaryFile);
+        List<String> command = Arrays.asList(CONVERT, AUTO_ORIENT, strip, importFile, temporaryFile);
         CommandUtility.executeCommand(command);
 
         return temporaryFile;

--- a/src/test/java/JP2ImageConverter/ImagePreprocessingIT.java
+++ b/src/test/java/JP2ImageConverter/ImagePreprocessingIT.java
@@ -177,12 +177,12 @@ public class ImagePreprocessingIT {
 
         assertTrue(Files.exists(Paths.get(tempTif)));
         var attributes = outputStreamCaptor.toString();
-        assertContains("ICCProfileName:sRGB IEC61966-2.1", attributes);
+        assertContains("ICCProfileName:", attributes);
         assertContains("MagickIdentify:", attributes);
         assertContains("Dimensions: 1228x1818;", attributes);
         assertContains("Channels: srgb", attributes);
         assertContains("Color Space: sRGB;", attributes);
-        assertContains("Profiles: icc;", attributes);
+        assertContains("Profiles:", attributes);
         assertContains("Type: TrueColor;", attributes);
     }
 

--- a/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
+++ b/src/test/java/JP2ImageConverter/services/ImagePreprocessingServiceTest.java
@@ -172,7 +172,7 @@ public class ImagePreprocessingServiceTest {
             String outputFile = service.convertToTifWithIm(testFile);
 
             mockedStatic.verify(() -> CommandUtility.executeCommand(
-                    new ArrayList<>(Arrays.asList("convert", "-auto-orient", testFile, outputFile))));
+                    new ArrayList<>(Arrays.asList("convert", "-auto-orient", "-strip", testFile, outputFile))));
         }
     }
 


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-5702](https://unclibrary.atlassian.net/browse/BXC-5702)

- add `-strip` option to `convertToTifWithIm` to remove embedded ICC Profiles
- modify tests